### PR TITLE
added -a flag to tree in Makefile and workflow

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -28,7 +28,7 @@ jobs:
         mkdir root
         cd root
         bash ../out-sample.sh
-        tree
+        tree -a
     - name: Clean
       run: make clean
     - name: Uninstall

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ FLEXFLAGS :=
 BISONFLAGS := -d
 RMFLAGS := -f
 CPFLAGS := 
-TREEFLAGS := 
+TREEFLAGS := -a
 
 # make
 


### PR DESCRIPTION
# Description

Added `-a` flag to the `tree` command in:
* [Makefile](https://github.com/RaisinTen/fs-make/blob/tree-flag-for-showing-all-files/Makefile#L59)
* [Workflow](https://github.com/RaisinTen/fs-make/blob/tree-flag-for-showing-all-files/.github/workflows/ccpp.yml#L31)

Fixes [# 4 - Dot files not showing up in tree command](https://github.com/RaisinTen/fs-make/issues/4#issue-627019836)

## Type of change

Please delete options that are not relevant.

- [x] bug-fixes

# How Has This Been Tested?

Passed the following run:

- [x] [Test A](https://github.com/RaisinTen/fs-make/runs/719389134?check_suite_focus=true)

**Test Configuration**:
* OS: ubuntu-latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
