### PR TITLE
changed cp to install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ RED := $(PRE)1;31m
 -include tools
 
 RM := rm
-CP := cp
+IN := install
 
 # flags
 
@@ -55,7 +55,7 @@ CFLAGS := $(DEFINES) -Wall -Wextra -Wpedantic -g -MMD -MP -c
 FLEXFLAGS := 
 BISONFLAGS := -d
 RMFLAGS := -f
-CPFLAGS := 
+INFLAGS := 
 TREEFLAGS := -a
 
 # make
@@ -69,7 +69,7 @@ uninstall:
 
 install:
 	@echo "$(GREEN)Installing $(TARGET)$(NC)"
-	$(CP) $(CPFLAGS) $(TARGET) $(BIN)/$(TARGET)
+	$(IN) $(INFLAGS) $(TARGET) $(BIN)/$(TARGET)
 
 $(TARGET): $(OBJECTS)
 	@echo "$(YELLOW)Making $@$(NC)"


### PR DESCRIPTION
# Description

Changed `cp` to `install` [here](https://github.com/RaisinTen/fs-make/blob/cp-to-install/Makefile#L72).

Fixes [# 6 - Use command install in make install](https://github.com/RaisinTen/fs-make/issues/6#issue-627672981)

## Type of change

- [x] bug-fixes

# How Has This Been Tested?

- [x] [Test A](https://github.com/RaisinTen/fs-make/runs/722698713?check_suite_focus=true)

**Test Configuration**:
* OS: ubuntu-latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
