### PR TITLE
changed _cplusplus to __cplusplus

### DIFF
--- a/node.h
+++ b/node.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -14,6 +14,6 @@ struct Node
 
 extern void clear(struct Node* node); // clears the memory allocated for node and its children
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Description

In [`node.h`](https://github.com/RaisinTen/fs-make/blob/master/node.h):
* [line 3](https://github.com/RaisinTen/fs-make/blob/master/node.h#L3)
* [line 17](https://github.com/RaisinTen/fs-make/blob/master/node.h#L17)

changed `_cplusplus` to `__cplusplus`

Fixes [#13 _cplusplus instead of __cplusplus in node.h](https://github.com/RaisinTen/fs-make/issues/13#issue-630761121)

## Type of change

- [x] bug-fixes

# How Has This Been Tested?

- [x] [Test A](https://github.com/RaisinTen/fs-make/actions/runs/124779978)

**Test Configuration**:
* OS: ubuntu-latest

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
